### PR TITLE
Change silnternational to sil-org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sil-org/php-devs

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 SIL International
+Copyright (c) 2016 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "silinternational/yii2-email-log-target",
+  "name": "sil-org/yii2-email-log-target",
   "version": "1.0.1",
   "type": "library",
   "description": "Yii2 log target for sending data to email without trace information",


### PR DESCRIPTION
### Changed
- Changed SIL International to SIL Global
- Changed silnternational to sil-org
- Added CODEOWNERS file